### PR TITLE
スタック作成をCLIからObsに変更

### DIFF
--- a/.circleci/Readme.md
+++ b/.circleci/Readme.md
@@ -1,3 +1,3 @@
-### コマンドやtips
+## コマンドやtips
 - circleci config validate
 - コミットメッセージに[ci skip]を含めるとciを実行しない

--- a/.circleci/Readme.md
+++ b/.circleci/Readme.md
@@ -1,0 +1,3 @@
+### コマンドやtips
+- circleci config validate
+- コミットメッセージに[ci skip]を含めるとciを実行しない

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   aws-cli:  circleci/aws-cli@2.0
+  aws-cloudformation: orbss/aws-cloudformation@0.1.6
   ansible-playbook: orbss/ansible-playbook@0.0.5
 
 jobs:
@@ -9,30 +10,10 @@ jobs:
     steps:
       - checkout
       - aws-cli/setup
-      - run:
-          name: "create stack"
-          command:  |
-            set +e 
-            aws cloudformation list-stacks --stack-status-filter UPDATE_COMPLETE | grep mystack
-            if [ $? -eq 0 ];  then
-              aws cloudformation update-stack \
-              --stack-name mystack \
-              --template-body file://service/infrastructure.yml
-              if [ $? -ne 0 ]; then
-                exit 0
-              fi
-              aws cloudformation wait stack-update-complete \
-              --stack-name mystack
-            else
-              aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE | grep mystack
-              if [ $? -ne 0 ];  then
-                aws cloudformation create-stack \
-                --stack-name mystack \
-                --template-body file://service/infrastructure.yml
-                aws cloudformation wait stack-create-complete \
-                --stack-name mystack
-              fi
-            fi
+      - aws-cloudformation/deploy:
+          template-file-path: /service/infrastructure.yml
+          stack-name: mystack
+          extra-arguments:  --no-fail-on-empty-changeses
             
   execute-ansible-playbook:
     executor: ansible-playbook/default
@@ -47,11 +28,9 @@ jobs:
           private-key: ANSIBLE_SSH_KEY
 
 workflows:
+  version:  2
   provisioning-deploy:
     jobs:
       - create-stack
-      - execute-ansible-playbook:
-          requires:
-            - create-stack
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - checkout
       - aws-cli/setup
       - aws-cloudformation/deploy:
-          template-file-path: /service/infrastructure.yml
+          template-file-path: service/infrastructure.yml
           stack-name: mystack
           extra-arguments:  --no-fail-on-empty-changeset
             

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   ansible-playbook: orbss/ansible-playbook@0.0.5
 
 jobs:
-  create-stack:
+  provisioning-stack:
     executor: aws-cli/default
     steps:
       - checkout
@@ -34,6 +34,10 @@ workflows:
   version:  2
   provisioning-deploy:
     jobs:
-      - create-stack
+      - provisioning-stack
+      - execute-ansible-playbook:
+          requires:
+            - provisioning-stack
+
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - checkout
       - aws-cli/setup
       - run:
-          name: "tempate validate"
+          name: "template validate"
           command: aws cloudformation validate-template --template-body file://service/infrastructure.yml
       - aws-cloudformation/deploy:
           template-file-path: service/infrastructure.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - checkout
       - aws-cli/setup
+      - run:
+          name: "tempate validate"
+          command: aws cloudformation validate-template --template-body file://service/infrastructure.yml
       - aws-cloudformation/deploy:
           template-file-path: service/infrastructure.yml
           stack-name: mystack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - aws-cloudformation/deploy:
           template-file-path: /service/infrastructure.yml
           stack-name: mystack
-          extra-arguments:  --no-fail-on-empty-changeses
+          extra-arguments:  --no-fail-on-empty-changeset
             
   execute-ansible-playbook:
     executor: ansible-playbook/default


### PR DESCRIPTION
## CLIとシェルスクリプトからObsに変更
- 使用したobsは：orbss/aws-cloudformation@0.1.6 
- 構文チェック追加 `aws cloudformation template-validate --template-body file://テンプレートファイル`
- Obsを使用してcreateもupdateも一つの構文で実行できる。更新がない場合にエラー落ちしないようにするオプション`--no-fail-on-empty-changeset`を使用